### PR TITLE
Change JMS serializer version to 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4",
         "simple-bus/asynchronous-bundle": "~2.0",
         "simple-bus/jms-serializer-bridge": "~1.0",
-        "jms/serializer-bundle": "~0.11",
+        "jms/serializer-bundle": "~0.11||~1.0",
         "symfony/framework-bundle": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
In the case you merge SimpleBus/JMSSerializerBridge#2 and then tag the version 1.1 for `JMSSerializerBridge`, here's the PR that upgrade the bundle :)
